### PR TITLE
feat: configure self-hosted Renovate app

### DIFF
--- a/.github/workflows/renovate-app.yml
+++ b/.github/workflows/renovate-app.yml
@@ -1,0 +1,19 @@
+name: Renovate App
+
+on:
+  workflow_dispatch:    
+  schedule:
+    - cron: '0/15 * * * *'
+
+jobs:
+  renovate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # tag=v3.1.0
+
+      - name: Self-hosted Renovate
+        uses: renovatebot/github-action@374c3608326859d984e5f5e17e3f94bc3979369a # tag=v34.10.0
+        with:
+          configurationFile: config.json
+          token: ${{ secrets.RENOVATE_TOKEN }}

--- a/.github/workflows/validate-config.yml
+++ b/.github/workflows/validate-config.yml
@@ -1,0 +1,25 @@
+name: Validate Renovate config
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  preset:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # tag=v3.1.0
+
+      - name: Validate config 
+        run: |
+          docker run \
+            --entrypoint=renovate-config-validator \
+            --volume "$(pwd):/tmp" \
+            renovate/renovate:slim /tmp/config.json

--- a/README.md
+++ b/README.md
@@ -1,10 +1,5 @@
-# Generic Project Template
+# Renovate App
 
-This repository provides some base files for setting up a repository at
-CDS. Plan is to create more project template for specific technologies:
+Self-hosted Renovate App running with a scheduled [GitHub Action](https://github.com/renovatebot/github-action).
 
-- project-template-terraform
-- project-template-python
-- project-template-nodejs
-
-Note that default community health files are maintained at https://github.com/cds-snc/.github 
+This will be used to perform dependency updates on projects that have secret values as part of their Renovate configuration.

--- a/config.json
+++ b/config.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "branchPrefix": "renovate/",
+  "username": "renovate-release",
+  "gitAuthor": "Renovate Bot <bot@renovateapp.com>",
+  "platform": "github",
+  "includeForks": false,
+  "detectHostRulesFromEnv": true,
+  "repositories": [
+    "cds-snc/gc-articles"
+  ]
+}


### PR DESCRIPTION
# Summary
Adds the Renovate app config and workflow to run Renovate against specific repos.

# Related
- cds-snc/platform-core-services#131