### PR TITLE
fix: renovate app commit sha

### DIFF
--- a/.github/workflows/renovate-app.yml
+++ b/.github/workflows/renovate-app.yml
@@ -11,7 +11,7 @@ jobs:
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # tag=v3.1.0
 
       - name: Self-hosted Renovate
-        uses: renovatebot/github-action@374c3608326859d984e5f5e17e3f94bc3979369a # tag=v34.10.0
+        uses: renovatebot/github-action@f65d704dc047d296dba50b502af53c4ae186e49f # tag=v34.10.0
         with:
           configurationFile: config.json
           token: ${{ secrets.RENOVATE_TOKEN }}


### PR DESCRIPTION
# Summary
Update the Renovate app action's commit SHA to the correct value.

# Related
- cds-snc/platform-core-services#146