### PR TITLE
feat: pass secrets to Renovate

### DIFF
--- a/.github/workflows/renovate-app.yml
+++ b/.github/workflows/renovate-app.yml
@@ -3,6 +3,12 @@ name: Renovate App
 on:
   workflow_dispatch:    
 
+env:
+  GITHUB_GITHUB_COM_TOKEN: ${{ secrets.COMPOSER_GITHUB_COM_TOKEN }}
+  PACKAGIST_MY_YOAST_COM_TOKEN: ${{ secrets.COMPOSER_MY_YOAST_COM_TOKEN }}
+  RENOVATE_WPML_KEY: ${{ secrets.WPML_KEY }}
+  RENOVATE_WPML_USER_ID: ${{ secrets.WPML_USER_ID }}
+
 jobs:
   renovate:
     runs-on: ubuntu-latest


### PR DESCRIPTION
# Summary
Update the Renovate app's config with secrets that will be used to check the Articles dependencies.  This is using two features from self-hosted renovate:

- [detecthostrulesfromenv](https://docs.renovatebot.com/self-hosted-configuration/#detecthostrulesfromenv)
- Passing `RENOVATE_` prefixed variables to the child process.

# Related
- cds-snc/platform-core-services#146
- cds-snc/platform-core-services#131
- cds-snc/platform-core-services#118