### PR TITLE
feat: run Renovate using GitHub app

### DIFF
--- a/.github/workflows/renovate-app.yml
+++ b/.github/workflows/renovate-app.yml
@@ -18,14 +18,14 @@ jobs:
           sed -i 's/%ARTICLES_YOAST_PASSWORD%/${{ secrets.ARTICLES_YOAST_PASSWORD }}/g' config.json
 
       - name: Get Renovate app token
-        id: renovate
-        uses: getsentry/action-github-app-token@97c9e23528286821f97fba885c1b1123284b29cc # tag=v2.0.0
+        id: get_token
+        uses: machine-learning-apps/actions-app-token@b5f0e20a640a9d046e57e5cbbb60159c18c2078c # tag=v0.21
         with:
-          app_id: ${{ secrets.APP_ID }}
-          private_key: ${{ secrets.APP_PEM }}
+          APP_PEM: ${{ secrets.APP_PEM }}
+          APP_ID: ${{ secrets.APP_ID }}
 
       - name: Renovate
         uses: renovatebot/github-action@f65d704dc047d296dba50b502af53c4ae186e49f # tag=v34.10.0
         with:
           configurationFile: config.json
-          token: 'x-access-token:${{ steps.renovate.outputs.token }}'
+          token: 'x-access-token:${{ steps.get_token.outputs.app_token }}'

--- a/.github/workflows/renovate-app.yml
+++ b/.github/workflows/renovate-app.yml
@@ -3,12 +3,6 @@ name: Renovate App
 on:
   workflow_dispatch:    
 
-env:
-  GITHUB_GITHUB_COM_TOKEN: ${{ secrets.COMPOSER_GITHUB_COM_TOKEN }}
-  PACKAGIST_MY_YOAST_COM_TOKEN: ${{ secrets.COMPOSER_MY_YOAST_COM_TOKEN }}
-  RENOVATE_WPML_KEY: ${{ secrets.WPML_KEY }}
-  RENOVATE_WPML_USER_ID: ${{ secrets.WPML_USER_ID }}
-
 jobs:
   renovate:
     runs-on: ubuntu-latest
@@ -16,8 +10,22 @@ jobs:
       - name: Checkout
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # tag=v3.1.0
 
-      - name: Self-hosted Renovate
+      - name: Add secrets to config
+        run: |
+          sed -i 's/%ARTICLES_WPML_KEY%/${{ secrets.ARTICLES_WPML_KEY }}/g' config.json
+          sed -i 's/%ARTICLES_WPML_USER_ID%/${{ secrets.ARTICLES_WPML_USER_ID }}/g' config.json
+          sed -i 's/%ARTICLES_YOAST_USERNAME%/${{ secrets.ARTICLES_YOAST_USERNAME }}/g' config.json
+          sed -i 's/%ARTICLES_YOAST_PASSWORD%/${{ secrets.ARTICLES_YOAST_PASSWORD }}/g' config.json
+
+      - name: Get app token
+        id: get_token
+        uses: machine-learning-apps/actions-app-token@b5f0e20a640a9d046e57e5cbbb60159c18c2078c # tag=v0.21
+        with:
+          APP_PEM: ${{ secrets.APP_PEM }}
+          APP_ID: ${{ secrets.APP_ID }}
+
+      - name: Renovate
         uses: renovatebot/github-action@f65d704dc047d296dba50b502af53c4ae186e49f # tag=v34.10.0
         with:
           configurationFile: config.json
-          token: ${{ secrets.RENOVATE_TOKEN }}
+          token: 'x-access-token:${{ steps.get_token.outputs.app_token }}'

--- a/.github/workflows/renovate-app.yml
+++ b/.github/workflows/renovate-app.yml
@@ -17,15 +17,15 @@ jobs:
           sed -i 's/%ARTICLES_YOAST_USERNAME%/${{ secrets.ARTICLES_YOAST_USERNAME }}/g' config.json
           sed -i 's/%ARTICLES_YOAST_PASSWORD%/${{ secrets.ARTICLES_YOAST_PASSWORD }}/g' config.json
 
-      - name: Get app token
-        id: get_token
-        uses: machine-learning-apps/actions-app-token@b5f0e20a640a9d046e57e5cbbb60159c18c2078c # tag=v0.21
+      - name: Get Renovate app token
+        id: renovate
+        uses: getsentry/action-github-app-token@97c9e23528286821f97fba885c1b1123284b29cc # tag=v2.0.0
         with:
-          APP_PEM: ${{ secrets.APP_PEM }}
-          APP_ID: ${{ secrets.APP_ID }}
+          app_id: ${{ secrets.APP_ID }}
+          private_key: ${{ secrets.APP_PEM }}
 
       - name: Renovate
         uses: renovatebot/github-action@f65d704dc047d296dba50b502af53c4ae186e49f # tag=v34.10.0
         with:
           configurationFile: config.json
-          token: 'x-access-token:${{ steps.get_token.outputs.app_token }}'
+          token: 'x-access-token:${{ steps.renovate.outputs.token }}'

--- a/config.json
+++ b/config.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "branchPrefix": "renovate/",
-  "username": "Renovate CDS",
+  "username": "renovate-cds[bot]",
   "gitAuthor": "Renovate Bot <bot@renovateapp.com>",
   "allowPlugins": true,
   "repositories": [

--- a/config.json
+++ b/config.json
@@ -1,12 +1,22 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "branchPrefix": "renovate/",
-  "username": "renovate-release",
+  "username": "Renovate CDS",
   "gitAuthor": "Renovate Bot <bot@renovateapp.com>",
-  "platform": "github",
-  "includeForks": false,
-  "detectHostRulesFromEnv": true,
+  "allowPlugins": true,
   "repositories": [
     "cds-snc/gc-articles"
-  ]
+  ],
+  "customEnvVariables": {
+    "WPML_KEY": "%ARTICLES_WPML_KEY%",
+    "WPML_USER_ID": "%ARTICLES_WPML_USER_ID%"    
+  },
+  "hostRules": [
+    {
+      "matchHost": "my.yoast.com",
+      "hostType": "packagist",
+      "username": "%ARTICLES_YOAST_USERNAME%",
+      "password": "%ARTICLES_YOAST_PASSWORD%"
+    }
+  ]  
 }


### PR DESCRIPTION
# Summary
Update Renovate config to use the CDS Renovate app.

Also updates the config so that secrets required to download Articles premium dependencies are injected.

# Related
- cds-snc/platform-core-services#146
- cds-snc/platform-core-services#131
- cds-snc/platform-core-services#118