### PR TITLE
feat: enable Renovate scheduled runs

### DIFF
--- a/.github/workflows/renovate-app.yml
+++ b/.github/workflows/renovate-app.yml
@@ -1,7 +1,9 @@
 name: Renovate App
 
 on:
-  workflow_dispatch:    
+  workflow_dispatch:
+  schedule:
+    - cron: '0/30 * * * *' # every 30 minutes
 
 jobs:
   renovate:


### PR DESCRIPTION
# Summary
Update Renovate workflow to run every 30 minutes.

# Related
- cds-snc/platform-core-services#146
- cds-snc/platform-core-services#118