### PR TITLE
chore: update self-hosted Renovate branch prefix

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "branchPrefix": "renovate/",
+  "branchPrefix": "renovate-cds/",
   "username": "renovate-cds[bot]",
   "gitAuthor": "Renovate Bot <bot@renovateapp.com>",
   "allowPlugins": true,


### PR DESCRIPTION
# Summary
Update the self-hosted Renovate app's branch prefix so that it does not conflict with the GitHub hosted Renovate app.