### PR TITLE
chore: enable debug logging

### DIFF
--- a/.github/workflows/renovate-app.yml
+++ b/.github/workflows/renovate-app.yml
@@ -28,6 +28,8 @@ jobs:
 
       - name: Renovate
         uses: renovatebot/github-action@f65d704dc047d296dba50b502af53c4ae186e49f # tag=v34.10.0
+        env:
+          LOG_LEVEL: debug
         with:
           configurationFile: config.json
           token: 'x-access-token:${{ steps.get_token.outputs.app_token }}'


### PR DESCRIPTION
# Summary
Enable debug logging for the Renovate App's workflow runs to troubleshoot an authentication issue.

# Related
- cds-snc/platform-core-services#146