### PR TITLE
feat: add GitHub metadata exporter workflow

### DIFF
--- a/.github/workflows/export-github-data.yml
+++ b/.github/workflows/export-github-data.yml
@@ -1,0 +1,19 @@
+name: GitHub repository metadata exporter
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "30 7 * * *"
+
+jobs:
+  export-data:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b
+      - name: Export Data
+        uses: ./
+        with:
+          github-app-id: ${{ secrets.SRE_BOT_RO_APP_ID }}
+          github-app-installation-id: ${{ secrets.SRE_BOT_RO_INSTALLATION_ID }}
+          github-app-private-key: ${{ secrets.SRE_BOT_RO_PRIVATE_KEY }}
+          log-analytics-workspace-id: ${{ secrets.LOG_ANALYTICS_WORKSPACE_ID }}
+          log-analytics-workspace-key: ${{ secrets.LOG_ANALYTICS_WORKSPACE_KEY }}


### PR DESCRIPTION
# Summary
Add a workflow to export GitHub repo metadata to Sentinel.

# Related
- cds-snc/platform-core-services#204