### PR TITLE
fix: use correct export action path

### DIFF
--- a/.github/workflows/export-github-data.yml
+++ b/.github/workflows/export-github-data.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b
       - name: Export Data
-        uses: ./
+        uses: cds-snc/github-repository-metadata-exporter@main
         with:
           github-app-id: ${{ secrets.SRE_BOT_RO_APP_ID }}
           github-app-installation-id: ${{ secrets.SRE_BOT_RO_INSTALLATION_ID }}


### PR DESCRIPTION
# Summary
Update to use the correct GitHub metadata exporter action path.