### PR TITLE
fix: use the full Renovate Docker image

### DIFF
--- a/.github/workflows/renovate-app.yml
+++ b/.github/workflows/renovate-app.yml
@@ -3,7 +3,7 @@ name: Renovate App
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0/30 * * * *' # every 30 minutes
+    - cron: '0 */4 * * *' # every 4 hours
 
 jobs:
   renovate:
@@ -31,3 +31,6 @@ jobs:
         with:
           configurationFile: config.json
           token: 'x-access-token:${{ steps.get_token.outputs.app_token }}'
+          useSlim: false
+        env:
+          LOG_LEVEL: debug


### PR DESCRIPTION
# Summary
Update to use the full Renovate Docker image.  This includes the Composer package manager needed by Articles.

Also update to only running the Renovate workflow once every 4 hours.