### PR TITLE
feat: onboard terraform-plan repo

### DIFF
--- a/config.json
+++ b/config.json
@@ -4,8 +4,12 @@
   "username": "renovate-cds[bot]",
   "gitAuthor": "Renovate Bot <bot@renovateapp.com>",
   "allowPlugins": true,
+  "allowedPostUpgradeCommands": [
+    "^npm run build$"
+  ],
   "repositories": [
-    "cds-snc/gc-articles"
+    "cds-snc/gc-articles",
+    "cds-snc/terraform-plan"
   ],
   "customEnvVariables": {
     "WPML_KEY": "%ARTICLES_WPML_KEY%",


### PR DESCRIPTION
# Summary
Update the config to use the self-hosted Renovate app on the Terraform plan action repo.

This will allow us to execute postUpgradeTasks against the repo that rebuild the `/dist` folder after dependency upgrades.