### PR TITLE
chore: allow `npm install` postUpgradeTask

### DIFF
--- a/config.json
+++ b/config.json
@@ -5,6 +5,7 @@
   "gitAuthor": "Renovate Bot <bot@renovateapp.com>",
   "allowPlugins": true,
   "allowedPostUpgradeCommands": [
+    "^npm install$",
     "^npm run build$"
   ],
   "repositories": [


### PR DESCRIPTION
# Summary
Update allowed post upgrade tasks to include `npm install`.