### PR TITLE
chore: allow `make release` post upgrade tasks

### DIFF
--- a/config.json
+++ b/config.json
@@ -5,11 +5,14 @@
   "gitAuthor": "Renovate Bot <bot@renovateapp.com>",
   "allowPlugins": true,
   "allowedPostUpgradeCommands": [
+    "^make release$",
     "^npm install$",
     "^npm run build$"
   ],
   "repositories": [
+    "cds-snc/dns-proxy-action",
     "cds-snc/gc-articles",
+    "cds-snc/github-repository-metadata-exporter",
     "cds-snc/terraform-plan"
   ],
   "customEnvVariables": {


### PR DESCRIPTION
# Summary
Update the config to allow `make release` post upgrade tasks and onboard two more repos.

# Related
- https://github.com/cds-snc/dns-proxy-action/pull/18
- https://github.com/cds-snc/github-repository-metadata-exporter/pull/131