### PR TITLE
feat: add GPG key for commit signing

### DIFF
--- a/.github/workflows/renovate-app.yml
+++ b/.github/workflows/renovate-app.yml
@@ -34,3 +34,4 @@ jobs:
           useSlim: false
         env:
           LOG_LEVEL: debug
+          RENOVATE_GIT_PRIVATE_KEY: ${{ secrets.RENOVATE_GIT_PRIVATE_KEY }}


### PR DESCRIPTION
# Summary
Update the Renovate app's config to include a GPG private key. This should enable the bot to sign commits.