### PR TITLE
fix: remove the custom GPG private key

### DIFF
--- a/.github/workflows/renovate-app.yml
+++ b/.github/workflows/renovate-app.yml
@@ -34,4 +34,3 @@ jobs:
           useSlim: false
         env:
           LOG_LEVEL: debug
-          RENOVATE_GIT_PRIVATE_KEY: ${{ secrets.RENOVATE_GIT_PRIVATE_KEY }}


### PR DESCRIPTION
# Summary
The GitHub app's commits are signed using GitHub's verified signature.

![image](https://github.com/cds-snc/renovate-app/assets/2110107/df98f485-d4ff-41d7-9b43-16a832b49c83)