### PR TITLE
fix: mount Docker socket in Renovate app

### DIFF
--- a/.github/workflows/renovate-app.yml
+++ b/.github/workflows/renovate-app.yml
@@ -12,6 +12,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@d70bba72b1f3fd22344832f00baa16ece964efeb # v3.3.0
+
       - name: Add secrets to config
         run: |
           sed -i 's/%ARTICLES_WPML_KEY%/${{ secrets.ARTICLES_WPML_KEY }}/g' config.json
@@ -31,6 +34,6 @@ jobs:
         with:
           configurationFile: config.json
           token: 'x-access-token:${{ steps.get_token.outputs.app_token }}'
-          useSlim: false
+          mount-docker-socket: true
         env:
           LOG_LEVEL: debug


### PR DESCRIPTION
# Summary
Fix `postUpgradeTasks` that rely on Docker and remove a deprecated config option:
https://github.com/renovatebot/github-action?tab=readme-ov-file#mount-docker-socket

Also install Docker Buildx in the workflow to remove deprecation warnings from Renovate artifact jobs.
