### PR TITLE
fix: add Node and update app token action

### DIFF
--- a/.github/workflows/renovate-app.yml
+++ b/.github/workflows/renovate-app.yml
@@ -12,8 +12,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - name: Set up Docker Buildx
+      - name: Setup Docker Buildx
         uses: docker/setup-buildx-action@6524bf65af31da8d45b59e8c27de4bd072b392f5 # v3.8.0
+
+      - name: Setup Node
+        uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4.2.0
+        with:
+          node-version: 'latest'
 
       - name: Add secrets to config
         run: |
@@ -23,17 +28,17 @@ jobs:
           sed -i 's/%ARTICLES_YOAST_PASSWORD%/${{ secrets.ARTICLES_YOAST_PASSWORD }}/g' config.json
 
       - name: Get Renovate app token
-        id: get_token
-        uses: machine-learning-apps/actions-app-token@b5f0e20a640a9d046e57e5cbbb60159c18c2078c # tag=v0.21
+        uses: actions/create-github-app-token@67e27a7eb7db372a1c61a7f9bdab8699e9ee57f7 # v1.11.3
+        id: app-token
         with:
-          APP_PEM: ${{ secrets.APP_PEM }}
-          APP_ID: ${{ secrets.APP_ID }}
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PEM }}
 
       - name: Renovate
         uses: renovatebot/github-action@0984fb80fc633b17e57f3e8b6c007fe0dc3e0d62 # v40.3.6
         with:
           configurationFile: config.json
-          token: 'x-access-token:${{ steps.get_token.outputs.app_token }}'
+          token: 'x-access-token:${{ steps.app-token.outputs.token }}'
           mount-docker-socket: true
         env:
           LOG_LEVEL: debug


### PR DESCRIPTION
# Summary
Add Node to the workflow so that Renovate can run `npm` commands.

Replace the 3rd party app token GitHub Action with the official action.
