### PR TITLE
fix: provide app token access to all repos in scope

### DIFF
--- a/.github/workflows/renovate-app.yml
+++ b/.github/workflows/renovate-app.yml
@@ -33,6 +33,7 @@ jobs:
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PEM }}
+          owner: ${{ github.repository_owner }}
 
       - name: Renovate
         uses: renovatebot/github-action@0984fb80fc633b17e57f3e8b6c007fe0dc3e0d62 # v40.3.6


### PR DESCRIPTION
# Summary
Update the Renovate app's token so that it has access to all repos that its GitHub app has access to.  With the previous config it was only being granted access to this repo and failing to create dependency PRs.