### PR TITLE
fix: allow pnpm install and build commands

### DIFF
--- a/config.json
+++ b/config.json
@@ -7,7 +7,8 @@
   "allowedCommands": [
     "^make release$",
     "^npm install$",
-    "^npm run build$"
+    "^pnpm install$",
+    "^pnpm build$"
   ],
   "repositories": [
     "cds-snc/dns-proxy-action",


### PR DESCRIPTION
# Summary
With the TF plan action switching to pnpm, we need to allow Renovate to run those commands after updates.  This will allow it to build new dist files for the action.

# Related
- https://github.com/cds-snc/terraform-plan/pull/575
