### PR TITLE
chore: onboard sso portal

### DIFF
--- a/config.json
+++ b/config.json
@@ -14,6 +14,7 @@
     "cds-snc/dns-proxy-action",
     "cds-snc/gc-articles",
     "cds-snc/github-repository-metadata-exporter",
+    "cds-snc/platform-unified-accounts-user-portal",
     "cds-snc/terraform-plan"
   ],
   "customEnvVariables": {


### PR DESCRIPTION
# Summary
Update the self-hosted app to scan the SSO user portal repo. This is because the Mend hosted version of Renvoate is consistently hitting OOM errors caused by the combination of that project's pnpm and Node versions.

# Related
- https://github.com/cds-snc/platform-core-services/issues/1019